### PR TITLE
"Skip includes" checkbox using correct settings value

### DIFF
--- a/src/main/kotlin/de/tschallacka/phpstormxdebugskip/settings/SettingsConfigurable.kt
+++ b/src/main/kotlin/de/tschallacka/phpstormxdebugskip/settings/SettingsConfigurable.kt
@@ -73,7 +73,7 @@ class SettingsConfigurable(private val project: Project) : Configurable {
 //        }
 //        panel.add(namespaceDecorator.createPanel())
         val skipincludes = JCheckBox("skip includes")
-        skipincludes.isSelected = skipConstructors
+        skipincludes.isSelected = skipIncludes
         skipincludes.addActionListener() {
             skipIncludes = skipincludes.isSelected
         }


### PR DESCRIPTION
Use the correct settings value for the "skip includes" checkbox because it was using the value from skipConstructors instead.